### PR TITLE
Convert files to eagle 7 format

### DIFF
--- a/Hardware/SparkFun_microSD_Breakout.brd
+++ b/Hardware/SparkFun_microSD_Breakout.brd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE eagle SYSTEM "eagle.dtd">
-<eagle version="7.2.0">
+<eagle version="7.5.0">
 <drawing>
 <settings>
 <setting alwaysvectorfont="yes"/>

--- a/Hardware/SparkFun_microSD_Breakout.sch
+++ b/Hardware/SparkFun_microSD_Breakout.sch
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE eagle SYSTEM "eagle.dtd">
-<eagle version="7.2.0">
+<eagle version="7.5.0">
 <drawing>
 <settings>
 <setting alwaysvectorfont="yes"/>


### PR DESCRIPTION
Older eagle files cannot be imported to kicad; this commit just updates the file format.